### PR TITLE
add rubocop-legion plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   ci:
     uses: LegionIO/.github/.github/workflows/ci.yml@main
 
-  lint:
-    uses: LegionIO/.github/.github/workflows/lint-patterns.yml@main
+  excluded-files:
+    uses: LegionIO/.github/.github/workflows/excluded-files.yml@main
 
   security:
     uses: LegionIO/.github/.github/workflows/security-scan.yml@main
@@ -27,7 +27,7 @@ jobs:
     uses: LegionIO/.github/.github/workflows/stale.yml@main
 
   release:
-    needs: [ci, lint]
+    needs: [ci, excluded-files]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: LegionIO/.github/.github/workflows/release.yml@main
     secrets:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,58 +1,6 @@
-AllCops:
-  TargetRubyVersion: 3.4
-  NewCops: enable
-  SuggestExtensions: false
+inherit_gem:
+  rubocop-legion: config/lex.yml
 
-Layout/LineLength:
-  Max: 160
-
-Layout/SpaceAroundEqualsInParameterDefault:
-  EnforcedStyle: space
-
-Layout/HashAlignment:
-  EnforcedHashRocketStyle: table
-  EnforcedColonStyle: table
-
-Metrics/MethodLength:
-  Max: 50
-
-Metrics/ClassLength:
-  Max: 1500
-
-Metrics/ModuleLength:
-  Max: 1500
-
-Metrics/BlockLength:
-  Max: 40
-  Exclude:
-    - 'spec/**/*'
-    - '*.gemspec'
-
-Metrics/AbcSize:
-  Max: 60
-
-Metrics/CyclomaticComplexity:
-  Max: 15
-
-Metrics/PerceivedComplexity:
-  Max: 17
-
-Style/Documentation:
-  Enabled: false
-
-Style/SymbolArray:
-  Enabled: true
-
-Style/FrozenStringLiteralComment:
-  Enabled: true
-  EnforcedStyle: always
-
+# Azure AI Foundry API requires many named keyword args per endpoint
 Metrics/ParameterLists:
   Max: 12
-
-Naming/FileName:
-  Enabled: false
-
-Naming/MethodParameterName:
-  AllowedNames:
-    - n

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.3] - 2026-03-30
+
+### Changed
+- update to rubocop-legion 0.1.7, resolve all offenses
+
 ## [0.1.2] - 2026-03-22
 
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,6 @@ gemspec
 group :test do
   gem 'rspec'
   gem 'rubocop'
+  gem 'rubocop-legion', '~> 0.1'
   gem 'simplecov'
 end

--- a/lib/legion/extensions/foundry.rb
+++ b/lib/legion/extensions/foundry.rb
@@ -10,7 +10,7 @@ require 'legion/extensions/foundry/client'
 module Legion
   module Extensions
     module Foundry
-      extend Legion::Extensions::Core if Legion::Extensions.const_defined? :Core
+      extend Legion::Extensions::Core if Legion::Extensions.const_defined? :Core, false
     end
   end
 end

--- a/lib/legion/extensions/foundry/runners/connections.rb
+++ b/lib/legion/extensions/foundry/runners/connections.rb
@@ -41,8 +41,8 @@ module Legion
               .delete("#{path}/#{name}?api-version=#{api_version}")
             { deleted: true }
           end
-          include Legion::Extensions::Helpers::Lex if Legion::Extensions.const_defined?(:Helpers) &&
-                                                      Legion::Extensions::Helpers.const_defined?(:Lex)
+          include Legion::Extensions::Helpers::Lex if Legion::Extensions.const_defined?(:Helpers, false) &&
+                                                      Legion::Extensions::Helpers.const_defined?(:Lex, false)
 
           private
 

--- a/lib/legion/extensions/foundry/runners/deployments.rb
+++ b/lib/legion/extensions/foundry/runners/deployments.rb
@@ -41,8 +41,8 @@ module Legion
               .delete("#{path}/#{name}?api-version=#{api_version}")
             { deleted: true }
           end
-          include Legion::Extensions::Helpers::Lex if Legion::Extensions.const_defined?(:Helpers) &&
-                                                      Legion::Extensions::Helpers.const_defined?(:Lex)
+          include Legion::Extensions::Helpers::Lex if Legion::Extensions.const_defined?(:Helpers, false) &&
+                                                      Legion::Extensions::Helpers.const_defined?(:Lex, false)
 
           private
 

--- a/lib/legion/extensions/foundry/runners/models.rb
+++ b/lib/legion/extensions/foundry/runners/models.rb
@@ -21,8 +21,8 @@ module Legion
             { model: response.body }
           end
 
-          include Legion::Extensions::Helpers::Lex if Legion::Extensions.const_defined?(:Helpers) &&
-                                                      Legion::Extensions::Helpers.const_defined?(:Lex)
+          include Legion::Extensions::Helpers::Lex if Legion::Extensions.const_defined?(:Helpers, false) &&
+                                                      Legion::Extensions::Helpers.const_defined?(:Lex, false)
         end
       end
     end

--- a/lib/legion/extensions/foundry/version.rb
+++ b/lib/legion/extensions/foundry/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Foundry
-      VERSION = '0.1.2'
+      VERSION = '0.1.3'
     end
   end
 end


### PR DESCRIPTION
## Summary
- Add rubocop-legion 0.1.7 with shared lex.yml config profile
- Replace inline .rubocop.yml with inherit_gem directive
- Update CI workflow to use excluded-files check
- Fix all rubocop offenses

## Test plan
- [ ] CI passes (rspec + rubocop)